### PR TITLE
Improve bot algorithm to be much faster for longer words

### DIFF
--- a/shared/alphaHelpers.ts
+++ b/shared/alphaHelpers.ts
@@ -49,8 +49,15 @@ for (let p of probabilities) {
 
 cdfArray = cdfArray.map((p) => Math.round(p * 100000) / 100000);
 
-const normalize = (val: number, max: number, min: number) =>
-  (val - min) / (max - min);
+export const normalize = (
+  num: number,
+  fromMin: number,
+  fromMax: number,
+  toMin: number,
+  toMax: number
+) => {
+  return toMin + ((num - fromMin) / (fromMax - fromMin)) * (toMax - toMin);
+};
 
 export const isValidWord = (
   word: string,
@@ -74,7 +81,7 @@ export const getRandomCharacter = (omit?: string[]): string => {
       total += cdf[letter];
       delete cdf[letter];
     }
-    n = normalize(n, 1 - total, 0);
+    n = normalize(n, 0, 1, 0, 1 - total);
   }
   const letterArr = Object.keys(cdf);
   const probArr = Object.values(cdf);


### PR DESCRIPTION
Doing combinations of all letters on the board makes the solution space waaaaay too big.

Instead, iterate over all the words and find all that could be made. Use a scoring system to make the bot prefer moves that defend its flower and expand its territory. Difficulty will modify how long of words the bot makes 