### PR TITLE
Simplify letter generation logic

### DIFF
--- a/server/src/routes/game.ts
+++ b/server/src/routes/game.ts
@@ -315,7 +315,7 @@ export default (io: Server) => {
     const move = req.body.move || [];
     for (const m of move) {
       if (typeof m == "object") {
-        if (m.q && typeof m.q == "number" && m.r && typeof m.r == "number") {
+        if (typeof m.q == "number" && typeof m.r == "number") {
           parsedMove.push({
             q: m.q,
             r: m.r,
@@ -336,7 +336,7 @@ export default (io: Server) => {
 
     let newGame: Game;
     try {
-      newGame = gm.makeMove(user, move);
+      newGame = gm.makeMove(user, parsedMove);
     } catch (e: unknown) {
       res.status(400);
       if (e instanceof Error) {

--- a/shared/hexgrid.ts
+++ b/shared/hexgrid.ts
@@ -116,50 +116,44 @@ export const getPotentialWords = (
   return potentialWords;
 };
 
+/**
+ * Iterate over the words dictionary, finding words that
+ * could be made using existing tiles on the board
+ * AND the new tiles we're about to reset.
+ *
+ * E.g. if lettersOnTheBoard is ["c", "a"] and resetTileTotal is 2
+ * we might return ["t", "z"]. The valid word being "cat". "t" completes the word
+ * and "z" is filler
+ */
 export const getNewCellValues = (
-  letters: string[],
-  toBeReset: number,
-  words: {
+  lettersOnTheBoard: string[],
+  resetTileTotal: number,
+  wordsJson: {
     [key: string]: number;
   }
 ): string[] => {
-  if (!toBeReset) {
+  if (!resetTileTotal) {
     return [];
   }
 
-  let w = Object.keys(words);
-  let potentialWords: string[] = [];
-  let combos: string[][] = [];
-  if (!letters.length) {
-    potentialWords = w.filter((word) => word.length <= toBeReset);
-  } else {
-    for (let i = 1; i <= letters.length; i++) {
-      combos = [...combos, ...combinationN(letters, i)];
-    }
-    combos = shuffle(combos);
+  let words = Object.keys(wordsJson);
 
-    for (let combo of combos) {
-      const validWords = w.filter((word) => {
-        const wordLetters = word.split("");
-        for (let letter of combo) {
-          const idx = wordLetters.indexOf(letter);
-          if (idx == -1) {
-            return false;
-          }
-          wordLetters.splice(idx, 1);
-        }
-        return wordLetters.length <= toBeReset;
-      });
-      if (!validWords.length) {
-        continue;
+  const wordsToMissingLetters = words.reduce((acc, word) => {
+    const wordLetters = word.split("");
+    for (let letter of lettersOnTheBoard) {
+      const idx = wordLetters.indexOf(letter);
+      if (idx != -1) {
+        wordLetters.splice(idx, 1);
       }
-      potentialWords = validWords;
-      break;
     }
-    if (!potentialWords.length) {
-      potentialWords = w.filter((word) => word.length <= toBeReset);
+    if (wordLetters.length <= resetTileTotal) {
+      acc[word] = wordLetters;
     }
-  }
+
+    return acc;
+  }, {} as { [key: string]: string[] });
+
+  const potentialWords = Object.keys(wordsToMissingLetters);
 
   if (!potentialWords.length) {
     throw "No possible combinations";
@@ -167,23 +161,14 @@ export const getNewCellValues = (
 
   const word = potentialWords[getRandomInt(0, potentialWords.length)];
 
-  const letters2 = R.clone(letters);
-  const neededLetters = [];
-  for (const letter of word.split("")) {
-    const idx = letters2.indexOf(letter);
-    if (idx === -1) {
-      neededLetters.push(letter);
-      continue;
-    }
-    letters2.splice(idx, 1);
-  }
+  const neededLetters = wordsToMissingLetters[word];
 
-  const fillerLength = toBeReset - neededLetters.length;
+  const fillerLength = resetTileTotal - neededLetters.length;
   let filler: string[] = [];
 
   for (let i = 0; i < fillerLength; i++) {
     const letterCount = R.countBy(R.identity, [
-      ...letters,
+      ...lettersOnTheBoard,
       ...neededLetters,
       ...filler,
     ]);

--- a/shared/hexgrid.ts
+++ b/shared/hexgrid.ts
@@ -117,6 +117,8 @@ export const getPotentialWords = (
 };
 
 /**
+ * Returns the letters that should appear on the tiles about to be reset.
+ *
  * Iterate over the words dictionary, finding words that
  * could be made using existing tiles on the board
  * AND the new tiles we're about to reset.
@@ -138,6 +140,17 @@ export const getNewCellValues = (
 
   let words = Object.keys(wordsJson);
 
+  /**
+   * Accomplishes two steps at once:
+   * 1. Filter for words that could be made now, or with the introduction our reset tiles
+   * 2. Determine what letters would need to be added to the board in order to make the word
+   *
+   * Returns an object like
+   *
+   * {
+   *  <word>: <letters needed>[]
+   * }
+   */
   const wordsToMissingLetters = words.reduce((acc, word) => {
     const wordLetters = word.split("");
     for (let letter of lettersOnTheBoard) {
@@ -163,9 +176,14 @@ export const getNewCellValues = (
 
   const neededLetters = wordsToMissingLetters[word];
 
+  /**
+   * If we can already make the word with letters on the board
+   * Or with a less than resetTileTotal, we need "random" letters as filler.
+   * This picks random characters as filler, but won't pick letters that
+   * appear more than MAX_REPEATED_LETTER times.
+   */
   const fillerLength = resetTileTotal - neededLetters.length;
   let filler: string[] = [];
-
   for (let i = 0; i < fillerLength; i++) {
     const letterCount = R.countBy(R.identity, [
       ...lettersOnTheBoard,


### PR DESCRIPTION
Fixes #100.

Letter generation logic was overly complex. Instead of generating every possible combination of tiles and checking it against the word dictionary, flip the script. Iterate over the dictionary and check if the word can be made. Gets rid of a lot of complexity and speeds things up quite a bit